### PR TITLE
Exposed an existing internal memory clearing function.

### DIFF
--- a/gettext-runtime/intl/finddomain.c
+++ b/gettext-runtime/intl/finddomain.c
@@ -191,10 +191,14 @@ out:
 }
 
 
-#ifdef _LIBC
+
 /* This is called from iconv/gconv_db.c's free_mem, as locales must
-   be freed before freeing gconv steps arrays.  */
-void __libc_freeres_fn_section
+   be freed before freeing gconv steps arrays.  
+*/
+void 
+#ifdef _LIBC
+__libc_freeres_fn_section
+#endif // ifdef _LIBC
 _nl_finddomain_subfreeres ()
 {
   struct loaded_l10nfile *runp = _nl_loaded_domains;
@@ -208,5 +212,14 @@ _nl_finddomain_subfreeres ()
       free ((char *) here->filename);
       free (here);
     }
+  /* We need to reinitialise the linked list. As we are using it
+	 at runtime and the link list may be accessed and point to
+	bad memory. */
+  _nl_loaded_domains = NULL;
 }
-#endif
+	  
+
+void wg_flush_loaded_domain_cache()
+{
+    _nl_finddomain_subfreeres();
+}

--- a/gettext-runtime/intl/libgnuintl.h
+++ b/gettext-runtime/intl/libgnuintl.h
@@ -19,6 +19,8 @@
 #ifndef _LIBINTL_H
 #define _LIBINTL_H 1
 
+#include "wg_hooks_internal.h"
+
 /* On Windows, variables that may be in a DLL must be marked specially.  */
 
 #if (defined _MSC_VER && defined _DLL) && !defined IN_RELOCWRAPPER
@@ -318,6 +320,7 @@ extern DLL_ROUTINE char *bind_textdomain_codeset (const char *__domainname,
        _INTL_ASM (libintl_bind_textdomain_codeset);
 #endif
 
+extern DLL_ROUTINE void wg_flush_loaded_domain_cache(void);
 extern DLL_ROUTINE void setGetLocaleHook(gettext_locale_hook);
 extern DLL_ROUTINE void setFileReaderHook(gettext_file_reader_hook);
 

--- a/gettext-runtime/intl/loadmsgcat.c
+++ b/gettext-runtime/intl/loadmsgcat.c
@@ -1316,29 +1316,34 @@ done:
 }
 
 
-#ifdef _LIBC
 void
-	internal_function __libc_freeres_fn_section
+	internal_function 
+#ifdef _LIBC
+	__libc_freeres_fn_section  // libc macro see. libc-symbols
+#endif
 	_nl_unload_domain (struct loaded_domain *domain)
 {
 	size_t i;
 
-	if (domain->plural != &__gettext_germanic_plural)
-		__gettext_free_exp ((struct expression *) domain->plural);
+	if (domain->plural != &GERMANIC_PLURAL)
+		FREE_EXPRESSION ((struct expression *) domain->plural);
 
 	for (i = 0; i < domain->nconversions; i++)
 	{
 		struct converted_domain *convd = &domain->conversions[i];
 
 		free (convd->encoding);
+#if HAVE_ICONV
 		if (convd->conv_tab != NULL && convd->conv_tab != (char **) -1)
 			free (convd->conv_tab);
 		if (convd->conv != (__gconv_t) -1)
 			__gconv_close (convd->conv);
+#endif // HAVE_ICONV
 	}
 	free (domain->conversions);
+#ifdef _LIBC
 	__libc_rwlock_fini (domain->conversions_lock);
-
+#endif
 	free (domain->malloced);
 
 # ifdef _POSIX_MAPPED_FILES
@@ -1350,4 +1355,3 @@ void
 
 	free (domain);
 }
-#endif


### PR DESCRIPTION
Hi, I have exposed an existing memory clearing function used by LIBC tools such as Valgrind (Used typically to free process memory for leak detection). The function clears the cache of loaded domain bindings allowing us to 'refresh' gettext with updated localizations during runtime. 

In finddomain.c: 
1. I have reordered the preprocessors to enable the function to always be compiled. 
2. I have reinitialises the _nl_loaded_domains list, else it points to garbage.
3. wrapped the  _nl_finddomain_subfreeres in our wg function

In loadmsgcat.c
1. As in finddomain.c I have reordered the preprocessors so the function is always compiled.
2. Switched out the specific data types for macros which are handled by preprocessors to point to the correct type. These can be found in \gettext-runtime\intl\plural-exp.h

In libgnuintl.h
1. I have added the new function declaration
2. Added wg_hooks_internal header as this was missing.